### PR TITLE
RTT detection patched

### DIFF
--- a/src/main/java/net/java/faker/WinRedirect.java
+++ b/src/main/java/net/java/faker/WinRedirect.java
@@ -85,7 +85,7 @@ public class WinRedirect {
         NETWORK, NETWORK_FORWARD
     }
 
-    public static native boolean setRedirectLatency(long redirect, String ip, int port, int latency);
+    public static native boolean setRedirectLatency(long redirect, String ip, int port, int latencyIn, int latencyOut);
 
     public static native int getRedirectLatency(long redirect, String ip, int port);
 

--- a/src/main/java/net/java/faker/proxy/session/ProxyConnection.java
+++ b/src/main/java/net/java/faker/proxy/session/ProxyConnection.java
@@ -527,22 +527,22 @@ public class ProxyConnection extends NetClient {
         this.latencyChange = latencyChange;
     }
 
-    public void setLatency(int latency) {
+    public void setLatency(int totalLatency) {
         if (this.latencyMode != LatencyMode.DISABLED) {
-            if (this.latency != latency) {
-                this.latency = latency;
+            if (this.latency != totalLatency) {
+                this.latency = totalLatency;
                 InetSocketAddress remote = (InetSocketAddress) this.c2p.remoteAddress();
                 String ip = remote.getAddress().getHostAddress();
                 int port = remote.getPort();
-                if (!WinRedirect.setRedirectLatency(Proxy.forward_redirect, ip, port, this.latency)) {
-                    WinRedirect.setRedirectLatency(Proxy.redirect, ip, port, this.latency);
+                int halfLatency = totalLatency / 2;
+                if (!WinRedirect.setRedirectLatency(Proxy.forward_redirect, ip, port, halfLatency, halfLatency)) {
+                    WinRedirect.setRedirectLatency(Proxy.redirect, ip, port, halfLatency, halfLatency);
                 }
                 if (latencyChange != null) {
                     latencyChange.accept(this);
                 }
             }
         }
-
     }
 
     public void setConnectTime(int connectTime) {


### PR DESCRIPTION
Related to issue [Flaw in ACK RTT time](https://github.com/o1seth/faker/issues/5)

Your approach was to add some latency between the client, faker local server, and the server
**Example case:**

```
Client -> Faker -> Server
    50ms     50ms
Total RTT: 100ms (50ms there + 50ms back)
Server sees: 100ms ping (because it's measuring the full RTT)

But the server's keep-alive packet:
Client <- Faker <- Server
    50ms     50ms
Total: 100ms again

```

The server is seeing double the actual latency because you're applying the same delay in both directions. This makes it somewhat obvious to RTT detection.

What I did: 

```
Client -> Faker -> Server
    25ms     25ms
Total: 50ms

Client <- Faker <- Server
    25ms     25ms
Total: 50ms

Server sees: 50ms ping (matches real RTT)
```

So now it should be completely undetected from Ack RTT time detection.